### PR TITLE
:sparkles: Add Subquery GraphQL API okp4-nemeton-1

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -12,8 +12,16 @@ sites:
   - name: Nemeton Program Web Site
     url: "https://nemeton.okp4.network"
   - name: RPC okp4-nemeton-1
-    url: >-
-      https://api.testnet.okp4.network/cosmos/base/tendermint/v1beta1/blocks/latest
+    url: "https://api.testnet.okp4.network/cosmos/base/tendermint/v1beta1/blocks/latest"
+  - name: Subquery GraphQL API okp4-nemeton-1
+    method: POST
+    url: "https://api.subquery.network/sq/okp4/nemeton-1"
+    headers:
+      - "Accept: application/json"
+      - "Content-Type: application/json"
+      - "Host: api.subquery.network"
+    body: '{ "query": "{blocks(last: 1) { nodes { chainId height } } }" }'
+    __dangerous__body_degraded: errors
 
 status-website:
   cname: status.okp4.network


### PR DESCRIPTION
Self explanatory.

Configured endpoint is similar to the following curl command:

```sh
curl -X POST -d '{ "query": "{blocks(last: 1) { nodes { chainId height } } }" }' -H "Accept: application/json" -H "Content-Type: application/json" -H "Host: api.subquery.network" https://api.subquery.network/sq/okp4/nemeton-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration for the Nemeton Program Web Site and RPC okp4-nemeton-1.
	- Introduced a new Subquery GraphQL API okp4-nemeton-1 with specific URL, method, headers, and body.
	- Included a degraded body attribute for the new API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->